### PR TITLE
Fix meta keywords tag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,7 +18,7 @@ const { title, description, keywords } = Astro.props;
 
     <meta name="title" content={title} />
     <meta name="description" content={description} />
-    <meta name="kewords" content={keywords} />
+    <meta name="keywords" content={keywords} />
 
     <!-- Facebook Meta Tags -->
     <meta property="og:url" content="" />


### PR DESCRIPTION
## Summary
- correct typo in meta keywords tag

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npx astro check` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_6882552f42a083329f660f37b3209f22